### PR TITLE
Fix serial ReadData calls in configuration scripts

### DIFF
--- a/FPGA/ElbertV2/tools/configuration/python/elbertconfig.py
+++ b/FPGA/ElbertV2/tools/configuration/python/elbertconfig.py
@@ -198,7 +198,11 @@ class ElbertConfigDownloader:
 		#before sending the last command. Input buffer can flushed by either calling 
 		#FlushInBuffer() routine or by reading large enough data from the input buffer.
 		#In most cases, simply calling CheckStatus() should clear the input buffer.
-		response = self.PortObj.ReadData(100)
+		# Use the driver's ReadData helper to fetch the response bytes
+		# from the serial port. ``serial.Serial`` exposes ``read`` and
+		# does not provide a ``ReadData`` method, so the previous call
+		# would raise an AttributeError.
+		response = self.ReadData(100)
 		print (response)
 		if len(response) > 38:
 			return 1

--- a/FPGA/Mimas/tools/configuration/python/mimasconfig.py
+++ b/FPGA/Mimas/tools/configuration/python/mimasconfig.py
@@ -197,7 +197,11 @@ class MimasConfigDownloader:
 		#before sending the last command. Input buffer can flushed by either calling 
 		#FlushInBuffer() routine or by reading large enough data from the input buffer.
 		#In most cases, simply calling CheckStatus() should clear the input buffer.
-		response = self.PortObj.ReadData(100)
+		# Read the response bytes from the serial port using our helper
+		# method. The ``serial.Serial`` object does not provide a
+		# ``ReadData`` attribute, so referencing it directly would raise
+		# an AttributeError.
+		response = self.ReadData(100)
 		print (response)
 		if len(response) > 38:
 			return 1

--- a/FPGA/MimasV2/tools/configuration/python/MimasV2Config.py
+++ b/FPGA/MimasV2/tools/configuration/python/MimasV2Config.py
@@ -171,7 +171,9 @@ class MimasV2ConfigDownloader:
 		#before sending the last command. Input buffer can flushed by either calling 
 		#FlushInBuffer() routine or by reading large enough data from the input buffer.
 		#In most cases, simply calling CheckStatus() should clear the input buffer.
-		response = mimasport.ReadData(100)
+		# Fetch the response bytes using our wrapper's ReadData method
+		# rather than an undefined external reference.
+		response = self.ReadData(100)
 		print (response)
 		if len(response) > 38:
 			return 1


### PR DESCRIPTION
## Summary
- use downloader's `ReadData` helper instead of undefined `ReadData` methods on serial objects
- document why the wrapper method is required to avoid AttributeError

## Testing
- `python -m py_compile FPGA/Mimas/tools/configuration/python/mimasconfig.py FPGA/ElbertV2/tools/configuration/python/elbertconfig.py FPGA/MimasV2/tools/configuration/python/MimasV2Config.py`


------
https://chatgpt.com/codex/tasks/task_e_689ea3f3c3d08320b69ad2ffa1c1f1a0