### PR TITLE
Fix comments in mimasconfig

### DIFF
--- a/FPGA/Mimas/tools/configuration/python/mimasconfig.py
+++ b/FPGA/Mimas/tools/configuration/python/mimasconfig.py
@@ -134,10 +134,10 @@ class MimasConfigDownloader:
 			
 	def SendData(self, Data):
 		'The lowest level routine to send raw data to Mimas'
-		'Returns total number of writes written'
+		'Returns total number of bytes written'
 		i = 0
 		bytesWritten = 0;
-		#Send data 30 bytes at a time. Mimas can recieve maximum 30 bytes per transaction
+		#Send data 30 bytes at a time. Mimas can receive maximum 30 bytes per transaction
 		while i < len(Data):
 			bytesWritten += self.PortObj.write(Data[i:i+30])
 			i += 30


### PR DESCRIPTION
## Summary
- clarify byte count comment in `SendData`
- fix typo in data transfer comment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea5b056f0832085b0e5a703aa99fc