### PR TITLE
Add relay index validation to demo sketch

### DIFF
--- a/Arduino/shields/2ChannelRelayShield/2ChannelRelayShieldDemoCode.ino
+++ b/Arduino/shields/2ChannelRelayShield/2ChannelRelayShieldDemoCode.ino
@@ -29,13 +29,20 @@ void loop()
       Serial.readBytesUntil(13, Input, 2);  // Read bytes until pressed ENTER
       int State = Input[1] - 48;
       int RelayNum = Input[0]-48;
-      if((State == 0) || (State == 1))
+      if (RelayNum < 0 || RelayNum >= 2)
       {
-         digitalWrite(RelayPins[RelayNum], State);  // Make Relay ON or OFF
+         Serial.println("Invalid relay number");
       }
       else
       {
-        Serial.println("Incorrect parameter");
+         if((State == 0) || (State == 1))
+         {
+            digitalWrite(RelayPins[RelayNum], State);  // Make Relay ON or OFF
+         }
+         else
+         {
+            Serial.println("Incorrect parameter");
+         }
       }
       
       Status = String("Relay ") + String(RelayNum) + String(" State is set to ") + String(State);


### PR DESCRIPTION
## Summary
- guard against invalid relay indices in 2ChannelRelayShield demo

## Testing
- `arduino-cli version` *(fails: command not found)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ea5aeac1883208bf58e6f6cd74932